### PR TITLE
Fix L3 node attribute: flag key

### DIFF
--- a/lib/netomox/topology/node_attr/base.rb
+++ b/lib/netomox/topology/node_attr/base.rb
@@ -10,10 +10,15 @@ module Netomox
     class L3NodeAttributeBase < AttributeBase
       # @!attribute [rw] prefixes
       #   @return [Array<L3Prefix>]
-      attr_accessor :prefixes
+      # @!attribute [rw] flags
+      #   @return [Array<String>]
+      attr_accessor :prefixes, :flags
 
       # Attribute definition of L3 node
-      ATTR_DEFS = [{ int: :prefixes, ext: 'prefix', default: [] }].freeze
+      ATTR_DEFS = [
+        { int: :prefixes, ext: 'prefix', default: [] },
+        { int: :flags, ext: 'flag', default: [] }
+      ].freeze
 
       include Diffable
 

--- a/lib/netomox/topology/node_attr/rfc.rb
+++ b/lib/netomox/topology/node_attr/rfc.rb
@@ -47,16 +47,13 @@ module Netomox
     class L3NodeAttribute < L3NodeAttributeBase
       # @!attribute [rw] name
       #   @return [String]
-      # @!attribute [rw] flags
-      #   @return [Array<String>]
       # @!attribute [rw] router_id
       #   @return [String]
-      attr_accessor :name, :flags, :router_id
+      attr_accessor :name, :router_id
 
       # Attribute definition of L3 node
       ATTR_DEFS = [
         { int: :name, ext: 'name', default: '' },
-        { int: :flags, ext: 'flag', default: [] },
         { int: :router_id, ext: 'router-id', default: '' }
       ].freeze
 

--- a/spec/topology/node_attr_mddo_spec.rb
+++ b/spec/topology/node_attr_mddo_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe 'check node attribute with RFC' do
           'prefix' => '172.16.2.0/24', 'next-hop' => '10.0.1.0',
           'metric' => 10, 'interface' => '', 'preference' => 1, 'description' => 'test'
         }
-      ]
+      ],
+      'flag' => []
     }
     expect(attr&.to_data).to eq expected_attr
   end


### PR DESCRIPTION
Mddo L3 Node Attribute の flag key が DSL 側と Topology 側でずれていたので修正。
DSL 側には flags があるのに Topology 側にはなかったので、config からトポロジデータを出すときには flag があるのに、json を読む段階で flag を読めていなかった。